### PR TITLE
Add support for BL808 UART2 and multiple IRQ forwards

### DIFF
--- a/arch/riscv/boot/dts/bouffalolab/Makefile
+++ b/arch/riscv/boot/dts/bouffalolab/Makefile
@@ -1,2 +1,3 @@
 # SPDX-License-Identifier: GPL-2.0
 dtb-$(CONFIG_SOC_BOUFFALOLAB) += bl808-sipeed-m1s.dtb
+dtb-$(CONFIG_SOC_BOUFFALOLAB) += bl808-pine64-ox64.dtb

--- a/arch/riscv/boot/dts/bouffalolab/bl808-pine64-ox64.dts
+++ b/arch/riscv/boot/dts/bouffalolab/bl808-pine64-ox64.dts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: (GPL-2.0+ or MIT)
+/*
+ * Copyright (C) 2022 Jisheng Zhang <jszhang@kernel.org>
+ */
+
+/dts-v1/;
+
+#include "bl808.dtsi"
+
+/ {
+	model = "Pine64 Ox64";
+	compatible = "sipeed,m1s", "bouffalolab,bl808";
+
+	aliases {
+		serial0 = &uart0;
+		serial1 = &uart1;
+	};
+
+	chosen {
+		stdout-path = "serial0:2000000n8";
+		bootargs = "console=ttyS0,2000000 loglevel=8 earlycon=sbi root=/dev/mtdblock0 ro rootfstype=squashfs";
+		linux,initrd-start = <0x0 0x52000000>;
+		linux,initrd-end = <0x0 0x52941784>;
+	};
+
+	memory@50000000 {
+		device_type = "memory";
+		reg = <0x50000000 0x04000000>;
+	};
+
+	xip_flash@58500000 {
+		compatible = "mtd-rom";
+		reg = <0x58500000 0x400000>;
+		linux,mtd-name = "xip-flash.0";
+		erase-size = <0x10000>;
+		bank-width = <4>;
+
+		rootfs@0 {
+			label = "rootfs";
+			reg = <0x00000 0x280000>;
+			read-only;
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&uart1 {
+	status = "okay";
+};
+
+&sdhci0 {
+	status = "okay";
+};
+
+&ipclic {
+	status = "okay";
+};

--- a/arch/riscv/boot/dts/bouffalolab/bl808.dtsi
+++ b/arch/riscv/boot/dts/bouffalolab/bl808.dtsi
@@ -60,7 +60,18 @@
 			clocks = <&xtal>;
 			status = "disabled";
 		};
-
+		
+		uart1: serial@0x2000AA00 {
+			compatible = "bouffalolab,uart";
+			reg = <0x2000AA00 0x0100>;
+			interrupts-extended = <&ipclic BFLB_IPC_SOURCE_M0
+								BFLB_IPC_DEVICE_UART2
+								IRQ_TYPE_EDGE_RISING>;
+			mboxes = <&ipclic BFLB_IPC_SOURCE_M0 BFLB_IPC_DEVICE_UART2>;
+			clocks = <&xtal>;
+			status = "disabled";
+		};
+		
 		sdhci0: sdhci@20060000 {
 			compatible = "bouffalolab,bflb-sdhci";
 			reg = <0x20060000 0x100>;

--- a/include/dt-bindings/mailbox/bflb-ipc.h
+++ b/include/dt-bindings/mailbox/bflb-ipc.h
@@ -12,5 +12,6 @@
 
 /* Peripheral device ID */
 #define BFLB_IPC_DEVICE_SDHCI		0
+#define BFLB_IPC_DEVICE_UART2		1
 
 #endif


### PR DESCRIPTION
This PR does the following:
- Adds an Ox64 specific device tree
- Adds BL808's UART2 to the base bl808 device tree
- Enables BL808's UART2 in the Ox64 device tree
- Uses the IPC interrupt forwarder for UART2's interrupt