### PR TITLE
IPC Mailbox Changes

### DIFF
--- a/arch/riscv/boot/dts/bouffalolab/bl808-pine64-ox64.dts
+++ b/arch/riscv/boot/dts/bouffalolab/bl808-pine64-ox64.dts
@@ -18,7 +18,7 @@
 
 	chosen {
 		stdout-path = "serial0:2000000n8";
-		bootargs = "console=ttyS0,2000000 loglevel=8 earlycon=sbi root=/dev/mmcblk0p2 rootwait rootfstype=ext4";
+		bootargs = "console=ttyS0,2000000 loglevel=8 earlycon=sbi root=/dev/mmcblk0p2 rootwait rootfstype=ext4 dyndbg=\"file drivers/remoteproc/* +p; file drivers/rpmsg/* +p; file drivers/virtio/* +p; file drivers/mailbox/* +p;\"";
 		linux,initrd-start = <0x0 0x52000000>;
 		linux,initrd-end = <0x0 0x52941784>;
 	};
@@ -27,6 +27,7 @@
 		device_type = "memory";
 		reg = <0x50000000 0x04000000>;
 	};
+
 
 	xip_flash@58500000 {
 		compatible = "mtd-rom";
@@ -53,6 +54,7 @@
 	status = "okay";
 };
 
-&enet0 {
+&rproc {
 	status = "okay";
 };
+

--- a/arch/riscv/boot/dts/bouffalolab/bl808.dtsi
+++ b/arch/riscv/boot/dts/bouffalolab/bl808.dtsi
@@ -59,6 +59,31 @@
 		#clock-cells = <0>;
 	};
 
+	reserved-memory {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+			/* putting this at the top of uncached WRAM for the moment */
+			vdev0vring0: vdev0vring0@22054000 {
+					compatible = "shared-dma-pool";
+					reg = <0x22050000 0x4000>;
+					no-map;
+			};
+
+			vdev0vring1: vdev0vring1@22055000 {
+					compatible = "shared-dma-pool";
+					reg = <0x22054000 0x4000>;
+					no-map;
+			};
+
+			vdev0buffer: vdev0buffer@22056000 {
+					compatible = "shared-dma-pool";
+					reg = <0x22042000 0x8000>;
+					no-map;
+			};
+	};
+
+
 	soc {
 		compatible = "simple-bus";
 		ranges;
@@ -139,6 +164,23 @@
 			#address-cells = <0>;
 			#interrupt-cells = <2>;
 			riscv,ndev = <64>;
+		};
+		
+		clint: timer@e4000000 {
+				compatible = "thead,c900-clint";
+				reg = <0xe4000000 0xc000>;
+				interrupts-extended = 	<&cpu0_intc 3>,
+										<&cpu0_intc 7>;
+		};
+
+
+		rproc: rproc@22054000 {
+			compatible = "bflb,bl808-rproc";
+			reg = <0x22054000 0x4000>;
+			memory-region = <&vdev0vring0>, <&vdev0vring1>, <&vdev0buffer>;
+			mboxes = <&ipclic BFLB_IPC_TARGET_M0 BFLB_IPC_MBOX_VIRTIO_KICK>;
+
+			status = "disabled";
 		};
 	};
 };

--- a/include/dt-bindings/mailbox/bflb-ipc.h
+++ b/include/dt-bindings/mailbox/bflb-ipc.h
@@ -13,7 +13,15 @@
 /* Peripheral device ID */
 #define BFLB_IPC_DEVICE_SDHCI		0
 #define BFLB_IPC_DEVICE_UART2		1
-#define BFLB_IPC_DEVICE_USB		2
+#define BFLB_IPC_DEVICE_USB		    2
 #define BFLB_IPC_DEVICE_EMAC		3
+#define BFLB_IPC_DEVICE_MBOX        5
+
+#define BFLB_IPC_TARGET_M0		0
+#define BFLB_IPC_TARGET_LP		1
+
+/* MailBox Signals */
+#define BFLB_IPC_MBOX_VIRTIO_KICK		1
+
 
 #endif


### PR DESCRIPTION
@arm000 
I've had a stab at updating the IPC driver for mailboxes but some of it I'm sure if a "hack". Mind having a look and giving some feedback as there were a few things I guess I wasn't sure how you planned to implement it:

* Mailbox's had a client and signal id. I"m assuming client was the CPU and Signal is the "data" to send over? I couldn't quite figure out how you intended for that to happen.
* in ```bflb_ipc_irq_fn``` i'm checking for the Mailbox IPC and branching off to the mailbox code to handle mbox messages. I'm not sure if thats ok, or we should be "registering" the mailbox with the IRQ subsystem?
* I'm not sending a EOI for mailbox messages currently (but checking if the other side processed mailbox messages by seeing if the High/Low registers are cleared. 

I've included the devicetree that is working for me, but as mentioned, i'm not sure the best way to model it. 

(for Virtio, there are two TX rings and two RX rings. I need to send/recieve via the mailbox which rings are updated, so I'm using one "bi-directional" mailbox with 0/1 as the payload to indicate right RX ring the other side needs to check)

Do you mind having a look at let me know?