### PR TITLE
Small dts fix

### DIFF
--- a/arch/riscv/boot/dts/bouffalolab/bl808-sipeed-m1s.dts
+++ b/arch/riscv/boot/dts/bouffalolab/bl808-sipeed-m1s.dts
@@ -33,6 +33,8 @@
 		linux,mtd-name = "xip-flash.0";
 		erase-size = <0x10000>;
 		bank-width = <4>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 
 		rootfs@0 {
 			label = "rootfs";


### PR DESCRIPTION
The number of address cells needed here (one) does not match the implicitly-defined default number of cells.

Signed-off-by: Samuel Holland <samuel@sholland.org>