### PR TITLE
Add timer node for OpenSBI 1.2 compatibility

### DIFF
--- a/arch/riscv/boot/dts/bouffalolab/bl808.dtsi
+++ b/arch/riscv/boot/dts/bouffalolab/bl808.dtsi
@@ -145,7 +145,7 @@
 			compatible = "thead,c900-clint";
 			reg = <0xe4000000 0xc000>;
 			interrupts-extended = <&cpu0_intc 3>,
-								<&cpu0_intc 7>;
+					      <&cpu0_intc 7>;
 		};
 	};
 };

--- a/arch/riscv/boot/dts/bouffalolab/bl808.dtsi
+++ b/arch/riscv/boot/dts/bouffalolab/bl808.dtsi
@@ -140,5 +140,12 @@
 			#interrupt-cells = <2>;
 			riscv,ndev = <64>;
 		};
+
+		clint: timer@e4000000 {
+			compatible = "thead,c900-clint";
+			reg = <0xe4000000 0xc000>;
+			interrupts-extended = <&cpu0_intc 3>,
+								<&cpu0_intc 7>;
+		};
 	};
 };


### PR DESCRIPTION
Currently only for OpenSBI 1.2 compatibility. 