### PR TITLE
Move USB driver from generic-echi to faraday,fotg210

### DIFF
--- a/arch/riscv/boot/dts/bouffalolab/bl808-pine64-ox64.dts
+++ b/arch/riscv/boot/dts/bouffalolab/bl808-pine64-ox64.dts
@@ -49,7 +49,7 @@
 	status = "okay";
 };
 
-&ehci0 {
+&usb0 {
 	status = "okay";
 };
 

--- a/arch/riscv/boot/dts/bouffalolab/bl808-sipeed-m1s.dts
+++ b/arch/riscv/boot/dts/bouffalolab/bl808-sipeed-m1s.dts
@@ -54,7 +54,7 @@
 	status = "okay";
 };
 
-&ehci0 {
+&usb0 {
 	status = "okay";
 };
 

--- a/arch/riscv/boot/dts/bouffalolab/bl808.dtsi
+++ b/arch/riscv/boot/dts/bouffalolab/bl808.dtsi
@@ -97,13 +97,15 @@
 			status = "disabled";
 		};
 
-		ehci0: usb@20072000 {
-			compatible = "generic-ehci";
+		usb0: usb@20072000 {
+			compatible = "faraday,fotg210";
 			reg = <0x20072000 0x1000>;
 			interrupts-extended = <&ipclic BFLB_IPC_SOURCE_M0
 						       BFLB_IPC_DEVICE_USB
 						       IRQ_TYPE_EDGE_RISING>;
 			clocks = <&xtal>;
+			mboxes = <&ipclic BFLB_IPC_SOURCE_M0 BFLB_IPC_DEVICE_USB>;
+			dr_mode = "peripheral";
 			status = "disabled";
 		};
 

--- a/arch/riscv/boot/dts/bouffalolab/bl808.dtsi
+++ b/arch/riscv/boot/dts/bouffalolab/bl808.dtsi
@@ -104,8 +104,7 @@
 						       BFLB_IPC_DEVICE_USB
 						       IRQ_TYPE_EDGE_RISING>;
 			clocks = <&xtal>;
-			mboxes = <&ipclic BFLB_IPC_SOURCE_M0 BFLB_IPC_DEVICE_USB>;
-			dr_mode = "peripheral";
+			dr_mode = "host";
 			status = "disabled";
 		};
 

--- a/drivers/usb/fotg210/Kconfig
+++ b/drivers/usb/fotg210/Kconfig
@@ -4,7 +4,7 @@ config USB_FOTG210
 	tristate "Faraday FOTG210 USB2 Dual Role controller"
 	depends on USB || USB_GADGET
 	depends on HAS_DMA && HAS_IOMEM
-	depends on ARCH_GEMINI || COMPILE_TEST
+	depends on SOC_BOUFFALOLAB || ARCH_GEMINI || COMPILE_TEST
 	default ARCH_GEMINI
 	select MFD_SYSCON
 	help

--- a/drivers/usb/fotg210/fotg210-hcd.c
+++ b/drivers/usb/fotg210/fotg210-hcd.c
@@ -5541,8 +5541,15 @@ static void fotg210_init(struct fotg210_hcd *fotg210)
 {
 	u32 value;
 
+#ifdef SOC_BOUFFALOLAB
+	/* Don't mess with interrupt polarity on BL808, since we actually
+	 receive a virtual interrupt since the USB is on a different core */
+
+	iowrite32(GMIR_MDEV_INT | GMIR_MOTG_INT, &fotg210->regs->gmir);
+#else
 	iowrite32(GMIR_MDEV_INT | GMIR_MOTG_INT | GMIR_INT_POLARITY,
 			&fotg210->regs->gmir);
+#endif
 
 	value = ioread32(&fotg210->regs->otgcsr);
 	value &= ~OTGCSR_A_BUS_DROP;

--- a/drivers/usb/fotg210/fotg210-hcd.c
+++ b/drivers/usb/fotg210/fotg210-hcd.c
@@ -5542,9 +5542,8 @@ static void fotg210_init(struct fotg210_hcd *fotg210)
 	u32 value;
 
 #ifdef CONFIG_SOC_BOUFFALOLAB
-	/* Don't mess with interrupt polarity on BL808, since we actually
-	 receive a virtual interrupt since the USB is on a different core */
-
+	/* Don't invert interrupt polarity on BL808, this is sorted out
+	 internally on the hardware implementation */
 	iowrite32(GMIR_MDEV_INT | GMIR_MOTG_INT, &fotg210->regs->gmir);
 #else
 	iowrite32(GMIR_MDEV_INT | GMIR_MOTG_INT | GMIR_INT_POLARITY,

--- a/drivers/usb/fotg210/fotg210-hcd.c
+++ b/drivers/usb/fotg210/fotg210-hcd.c
@@ -5541,7 +5541,7 @@ static void fotg210_init(struct fotg210_hcd *fotg210)
 {
 	u32 value;
 
-#ifdef SOC_BOUFFALOLAB
+#ifdef CONFIG_SOC_BOUFFALOLAB
 	/* Don't mess with interrupt polarity on BL808, since we actually
 	 receive a virtual interrupt since the USB is on a different core */
 

--- a/drivers/usb/fotg210/fotg210-udc.c
+++ b/drivers/usb/fotg210/fotg210-udc.c
@@ -1036,9 +1036,16 @@ static void fotg210_init(struct fotg210_udc *fotg210)
 {
 	u32 value;
 
-	/* disable global interrupt and set int polarity to active high */
+	/* disable global interrupt */
+#ifdef CONFIG_SOC_BOUFFALOLAB
+	/* Don't mess with interrupt polarity on BL808, since we actually
+	 receive a virtual interrupt since the USB is on a different core */
+	iowrite32(GMIR_MHC_INT | GMIR_MOTG_INT, fotg210->reg + FOTG210_GMIR);
+#else
+	/*and set int polarity to active high */
 	iowrite32(GMIR_MHC_INT | GMIR_MOTG_INT | GMIR_INT_POLARITY,
 		  fotg210->reg + FOTG210_GMIR);
+#endif
 
 	/* disable device global interrupt */
 	value = ioread32(fotg210->reg + FOTG210_DMCR);

--- a/drivers/usb/fotg210/fotg210-udc.c
+++ b/drivers/usb/fotg210/fotg210-udc.c
@@ -1024,6 +1024,18 @@ static int fotg210_udc_start(struct usb_gadget *g,
 			dev_err(fotg210->dev, "can't bind to phy\n");
 	}
 
+	/* software reset */
+	value = ioread32(fotg210->reg + FOTG210_DMCR);
+	value |= DMCR_SFRST;
+	iowrite32(value, fotg210->reg + FOTG210_DMCR);
+
+	mdelay(10);
+
+	value = ioread32(fotg210->reg + FOTG210_DAR);
+	value |= DAR_AFT_CONF;
+	iowrite32(value, fotg210->reg + FOTG210_DAR);
+
+	
 	/* enable device global interrupt */
 	value = ioread32(fotg210->reg + FOTG210_DMCR);
 	value |= DMCR_GLINT_EN;

--- a/drivers/usb/fotg210/fotg210-udc.c
+++ b/drivers/usb/fotg210/fotg210-udc.c
@@ -1035,7 +1035,6 @@ static int fotg210_udc_start(struct usb_gadget *g,
 	value |= DAR_AFT_CONF;
 	iowrite32(value, fotg210->reg + FOTG210_DAR);
 
-	
 	/* enable device global interrupt */
 	value = ioread32(fotg210->reg + FOTG210_DMCR);
 	value |= DMCR_GLINT_EN;
@@ -1050,8 +1049,8 @@ static void fotg210_init(struct fotg210_udc *fotg210)
 
 	/* disable global interrupt */
 #ifdef CONFIG_SOC_BOUFFALOLAB
-	/* Don't mess with interrupt polarity on BL808, since we actually
-	 receive a virtual interrupt since the USB is on a different core */
+	/* Don't invert interrupt polarity on BL808, this is sorted out
+	 internally on the hardware implementation */
 	iowrite32(GMIR_MHC_INT | GMIR_MOTG_INT, fotg210->reg + FOTG210_GMIR);
 #else
 	/*and set int polarity to active high */


### PR DESCRIPTION
This moves the USB driver from the generic ehci driver to the fotg210 driver, which seems to be a better fit.

With this in place we can use the BL808 as a USB host device. There are issues with some devices connecting properly on Ox64 and M1S boards, but this matches the behavior we see with the Bouffalo Labs SDK running on bare metal so it's not a regression. Work is continuing on getting things to work as a peripheral.

For the host device to be activated, a usbphy routine must power up the usb device in either low level boot or U-Boot. I have a companion patch with a reference implementation for OBLFR here:

https://github.com/openbouffalo/OBLFR/pull/9

